### PR TITLE
Multi-word functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,23 @@
 English to Piglatin translator. I downloaded SoloLearn on my phone and was presented with the challenge to make an english to piglatin translator. This is what I came up with. 
 
 This is actually my first time writing code without a "code along" type setting (video or book). 
+
+Original prompt:
+    Pig Latin
+    
+    Pig Latin is an argot ("secret" language) in which words in English are altered to conceal the words from others not familiar with the rules. 
+
+    You convert a word to pig latin by transferring the initial consonant or consonant cluster of the word to the end of the word with -ay appended to the end. If the word starts with a vowel (including y), append -yay to the end. For example, "pig" would become igpay (taking the 'p' and 'ay' to create a suffix).
+
+    Examples:
+
+        Input: say
+        Output: aysay
+
+        Input: english
+        Output: englishyay
+
+        Input: smile
+        Output: ilesmay
+
+    Write a program that translates the user input (an English word) to Pig Latin.

--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
 </head>
 
 <body>
-	<form>
+	<div>
 		<label>
 			translate english to piglatin <br>
 			<input type="text" id="word" name="word" autocomplete="off"><br>
 			<input type="button" id="submit" value="translate">
 		</label>
-	</form>
+	</div>
 	<hr>
 	<p><span id="trans"></span></p>
 	<script type="text/javascript" src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -15,9 +15,19 @@ inputBox.addEventListener("keydown", function(e){
 
 //recieve input from text box
 function getWord() {
-	let x = document.getElementById("word").value;
-	translate(x.toLowerCase());
+	let textInput = document.getElementById("word").value;
+	let wordsArr = textInput.split(" ");
+	document.getElementById("trans").innerHTML = "";
+	let translatedArr = [];
+	for (let i = 0; i < wordsArr.length; i++) {
+		const word = wordsArr[i].toLowerCase();
+		translatedArr.push(translate(word));
+
+	}
 };
+
+//loop through each word and translate it
+
 
 //translate word
 function translate(word) {
@@ -55,7 +65,7 @@ function translate(word) {
 function disp(arr) {
 	let trans = arr.join("");
 	//add translation to html page
-	document.getElementById("trans").innerHTML = trans;
+	document.getElementById("trans").innerHTML += trans += " ";
 };
 
 function vowels(arr) {

--- a/script.js
+++ b/script.js
@@ -1,17 +1,38 @@
-let vowel = ["a", "e", "i", "o", "u"];
+const vowel = ["a", "e", "i", "o", "u"];
 let isConstonant = true;
 let isNormal = true;
 
 //input listeners for pressing enter and click
-let inputBox = document.getElementById("word");
+let textBox = document.getElementById("word");
 const submitButton = document.getElementById("submit");
 submitButton.addEventListener("click", getWord, false);
-//pressing enter works for a second, then the word disappears. ?
-inputBox.addEventListener("keydown", function(e){
-	if(e.keyCode === 13){
-		getWord();
+
+//be able to press enter after typing word, instead of clicking button
+textBox.addEventListener("keyup", pressEnter => {
+	if(pressEnter.keyCode === 13){
+		submitButton.click();
 	}
 });
+
+/* 
+// Get the input field
+var input = document.getElementById("myInput");
+
+// Execute a function when the user releases a key on the keyboard
+input.addEventListener("keyup", function(event) {
+  // Cancel the default action, if needed
+  event.preventDefault();
+  // Number 13 is the "Enter" key on the keyboard
+  if (event.keyCode === 13) {
+    // Trigger the button element with a click
+    document.getElementById("myBtn").click();
+  }
+}); */
+
+
+
+
+
 
 //recieve input from text box
 function getWord() {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-form {
+div {
   height: 260px;
   width: auto;
   background: #FFF;


### PR DESCRIPTION
Added multi-word capability in the translator, as apposed to handling just one word at a time.

Fixed the "enter" bug - pressing enter would originally make the text on the page disappear and append to the url. Figured out it was because the text box was wrapped in <form> tags in the html file.

Made some minor changes to variable names.